### PR TITLE
Fixed hard-wired whats-the-score title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ db/scribe*
 log/*.log
 tmp/**/*
 db/mongod.lock
+.project
+config/mongodb.yml
+config/site_settings.yml

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Whats the score at the Bodleian</title>
+  <title><%= SiteConfig.application_name %></title>
   <%= stylesheet_link_tag :all %>
   <%= javascript_include_tag 'jquery-1.4.4.js' %>
   <%= javascript_include_tag 'rails' %>


### PR DESCRIPTION
This is my first pull request to the Zooniverse Scribe codebase.  

It contains two commits; one of which is a useful minor bug-fix to pull
the application title from config/site_settings.yml, and the other of which
is a .gitignore change of dubious value.
