### PR TITLE
Minor changes to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@ a user through the process of transcribing an asset (an image).
 
 ## Getting Started
 
-- We first need to install a mongodb server. This is then specified in config/mongodb.yml (see config/mongodb.hudson.yml for an example). Since databases are created lazily in MongoDB just specify the database name you want to use there.
+- First install the dependency gems running
+
+  `bundle install`
+
+- We then need to install a mongodb server. This is then specified in config/mongodb.yml (see config/mongodb.hudson.yml for an example). Since databases are created lazily in MongoDB just specify the database name you want to use there.
+
+  `cp config/mongodb.hudson.yml config/mongodb.yml`
 
 - Site settings (config/site_settings.hudson.yml) contains the application name and other detail about the project. You should rename site_settings.hudson.yml to site_settings.yml
+ 
+  `cp config/site_settings.hudson.yml config/site_settings.yml`
 
 - To generate the templates for the project look at the lib/tasks/sample_weather_bootstrap.rake file. You need to specify each entity type you wish transcribed and its fields along with help text for the user for each.
 


### PR DESCRIPTION
Added a step calling gem install as instructions on copying the config files from the *.hudson.yml templates, such that the deployer can easily copy past commands.
